### PR TITLE
Support waitFor and waitForTimeout

### DIFF
--- a/lib/scripts/conversionScriptPart.js
+++ b/lib/scripts/conversionScriptPart.js
@@ -75,9 +75,46 @@ page.open(body.url, function () {
         page.customHeaders = body.customHeaders;
     }
 
+    /*jshint -W061 */
+    var waitForFunc = body.waitFor ? eval('(function () { ' + body.waitFor + ' })') : undefined;
+    var waitForTimeout = body.waitForTimeout || 8000;
+    var waitForTimeoutTimer = setTimeout(function () {
+      waitForTimeoutTimer = undefined;
+    }, waitForTimeout);
+
     setTimeout(function () {
+        returnPage(waitForFunc);
+    }, body.printDelay || 0);
+
+    function returnPage (waitForFunc)
+    {
+        if (waitForFunc) {
+            if (waitForTimeoutTimer === undefined) {
+              // Failed to pass waitFor test within specified timeout
+              res.statusCode = 500;
+              res.write(JSON.stringify({
+                message: 'waitForTimeoutTimer exceeded'
+              }));
+              res.close();
+              return;
+            }
+
+            var pageLoaded = page.evaluate(waitForFunc);
+
+            if (!pageLoaded) {
+                // Try again
+                setTimeout(function () {
+                  returnPage (waitForFunc);
+                }, 100);
+                return;
+            }
+
+            // Success - return page
+            returnPage();
+            return;
+        }
+
         page.render(body.output, body.format);
         respond(page, body);
-
-    }, body.printDelay || 0);
+    }
 });


### PR DESCRIPTION
Adds support for `waitFor` and `waitForTimeout`:

```
htmlToPdf({
    waitFor: 'return window.pageLoaded === true;',
    waitForTimeout: 10000
});
```

`waitFor` is passed in as a string as it later gets JSON.stringified (and so passing in a function doesn't work).

Same improvement would need to be reflected in standalone script before release.