### PR TITLE
add workaround changing zoom on linux

### DIFF
--- a/lib/scripts/conversionScriptPart.js
+++ b/lib/scripts/conversionScriptPart.js
@@ -8,6 +8,11 @@ page.viewportSize = {
 page.settings.javascriptEnabled = body.settings.javascriptEnabled !== false;
 page.settings.resourceTimeout = body.settings.resourceTimeout || 1000;
 
+var linuxZoomFixStyle =
+  system.os.name === 'windows' ? "" :
+  "<style>body { transform-origin: 0 0; -webkit-transform-origin: 0 0; transform: scale(0.654545); -webkit-transform: scale(0.654545); }</style>";
+
+
 page.onResourceRequested = function (request, networkRequest) {
     if (request.url.lastIndexOf(body.url, 0) === 0) {
         return;
@@ -60,6 +65,15 @@ page.open(body.url, function () {
         return document.querySelector(s) ? document.querySelector(s).innerHTML : null;
     }, '#phantomFooter');
 
+    if (system.os.name !== 'windows') {
+        page.evaluate(function() {
+            document.body.style["transform-origin"] = "0 0";
+            document.body.style["-webkit-transform-origin"] = "0 0";
+            document.body.style["transform"] = "scale(0.654545)";
+            document.body.style["-webkit-transform"] = "scale(0.654545)";
+        });
+    }
+
     body.numberOfPages = 0;
 
     page.paperSize = {
@@ -82,7 +96,7 @@ page.open(body.url, function () {
                     stream.close();
                 }
 
-                return phantomHeader.replace(/{#pageNum}/g, pageNum).replace(/{#numPages}/g, numPages);
+                return linuxZoomFixStyle + phantomHeader.replace(/{#pageNum}/g, pageNum).replace(/{#numPages}/g, numPages);
             })
         },
         footer: (body.footerFile || phantomFooter) ? {
@@ -94,7 +108,7 @@ page.open(body.url, function () {
                     stream.close();
                 }
 
-                return phantomFooter.replace(/{#pageNum}/g, pageNum).replace(/{#numPages}/g, numPages);
+                return linuxZoomFixStyle + phantomFooter.replace(/{#pageNum}/g, pageNum).replace(/{#numPages}/g, numPages);
             })
         } : undefined
     };


### PR DESCRIPTION
The pdf generated on linux and windows looks differently. The issue is described [here](https://github.com/ariya/phantomjs/issues/12685). I have tried the proposed workaround and it is partially working. The output pdf files are still a little bit different, but it is not that significant. 

This result is the most far I got:
[linux.pdf](https://github.com/pofider/phantom-html-to-pdf/files/15931/linux.pdf)
[windows.pdf](https://github.com/pofider/phantom-html-to-pdf/files/15932/windows.pdf)

I guess this should be an optional behavior user can opt in. However we should for sure recommend the users to design pdf files on the same platform where the production will run.


