### PR TITLE
Phantom path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ conversion({ html: "<h1>Hello World</h1>" }, function(err, pdf) {
 ##Global options
 ```js
 var conversion = require("phantom-html-to-pdf")({
-    /* number of allocated phantomjs processes */
+	/* number of allocated phantomjs processes */
 	numberOfWorkers: 2,
 	/* timeout in ms for html conversion, when the timeout is reached, the phantom process is recycled */
 	timeout: 5000,
@@ -29,12 +29,17 @@ var conversion = require("phantom-html-to-pdf")({
 	portRightBoundary: 2000,
 	/* optional hostname where to start phantomjs server */
 	host: '127.0.0.1',
-	/* use rather dedicated process for every phantom printing 
-	  dedicated-process strategy is quite slower but can solve some bugs 
-	  with corporate proxy */	
-	strategy: "phantom-server | dedicated-process"
+	/* use rather dedicated process for every phantom printing
+	  dedicated-process strategy is quite slower but can solve some bugs
+	  with corporate proxy */
+	strategy: "phantom-server | dedicated-process",
+	/* optional path to the phantomjs binary
+	   NOTE: When using phantomjs 2.0, be aware of https://github.com/ariya/phantomjs/issues/12685 */
+	phantomPath: "{path to phantomjs}"
 });
 ```
+
+
 
 ##Local options
 

--- a/lib/conversion.js
+++ b/lib/conversion.js
@@ -80,6 +80,9 @@ module.exports = function (opt) {
     options.pathToPhantomScript = options.pathToPhantomScript || path.join(__dirname, "scripts", "serverScript.js");
     options.tmpDir = options.tmpDir || tmpDir;
     options.strategy = options.strategy || "phantom-server";
+    if (opt.phantomPath) {
+        options.phantomPath = opt.phantomPath;
+    }
 
     // always set env var names for phantom-workers (don't let the user override this config)
     options.hostEnvVarName = 'PHANTOM_WORKER_HOST';

--- a/lib/dedicatedProcessStrategy.js
+++ b/lib/dedicatedProcessStrategy.js
@@ -1,10 +1,13 @@
 var path = require("path"),
     childProcess = require('child_process'),
-    phantomjs = require('phantomjs'),
     fs = require("fs");
 
 
 module.exports = function(options, requestOptions, id, cb) {
+    if (!options.phantomPath) {
+        options.phantomPath = require('phantomjs').path;
+    }
+
     var settingsFilePath = path.resolve(path.join(options.tmpDir, id + "settings.html"));
 
     fs.writeFile(settingsFilePath, JSON.stringify(requestOptions), function (err) {
@@ -22,7 +25,7 @@ module.exports = function(options, requestOptions, id, cb) {
         var isDone = false;
 
         var numberOfPages = 1;
-        var child = childProcess.execFile(phantomjs.path, childArgs, function (err, stdout, stderr) {
+        var child = childProcess.execFile(options.phantomPath, childArgs, function (err, stdout, stderr) {
             if (isDone)
                 return;
 

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
   },
   "dependencies": {
     "phantom-workers": "0.3.1",
-    "phantomjs": "1.9.17",
     "underscore": "1.8.2",
     "uuid": "2.0.1"
   },
+  "optionalDependencies": {
+    "phantomjs": "1.9.17"
+  }
   "devDependencies": {
     "mocha": "2.1.0",
     "should": "5.0.1"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "optionalDependencies": {
     "phantomjs": "1.9.17"
-  }
+  },
   "devDependencies": {
     "mocha": "2.1.0",
     "should": "5.0.1"


### PR DESCRIPTION
@pofider 

Thanks for the great library! I tried it out and got PDF rendering from a URL working locally using the phantom-html-to-pdf module. I went to deploy to my AWS EC2 instance and found that the node phantomjs 1.9.15 doesn't properly load on Amazon Linux. To get around this, I implemented the ability to set a path to the phantomjs binary, which seems to be standard in other libraries that rely on phantom, e.g. https://github.com/brenden/node-webshot.

This change will work standalone for the dedicatedProcess strategy, but relies on https://github.com/pofider/phantom-workers/pull/10 for the server strategy. That will require a new release of https://github.com/pofider/phantom-workers and a change to the version of that dependency in `package.json`.

Testing:

* Tested without setting the new `phantomPath` option - uses phantomjs 1.9.15, and works on Mac OSX Yosemite 10.10.15.
* Tested adding a dependency to phantomjs2 - 2.0.0 and setting the `phantomPath` to `require('phantomjs2').path` - works on Mac OSX 10.10.15. I noticed features in phantomjs 2.0, such as web fonts to indicate that it was working.
* Tested bundling a custom Amazon Linux binary of phantomjs2 and setting the `phantomPath` to that on my AWS EC2 instances - works on AWS Elastic Beanstalk with 64bit Amazon Linux 2015.03 v2.0.0 running Node.js
* Tested both the `dedicated-process` strategy and the `phantom-server` strategy (using changes in https://github.com/pofider/phantom-workers/pull/10)