### PR TITLE
Clone the options var.

### DIFF
--- a/lib/conversion.js
+++ b/lib/conversion.js
@@ -33,8 +33,8 @@ function writeHtml(opt, id, cb) {
     });
 }
 
-function convert(options, cb) {
-    var opt = _.cloneDeep(options);
+function convert(conversionOptions, cb) {
+    var opt = _.cloneDeep(conversionOptions);
     if (typeof opt == 'string' || opt instanceof String) {
         opt = {
             html: opt

--- a/lib/conversion.js
+++ b/lib/conversion.js
@@ -1,7 +1,8 @@
 var path = require("path"),
     fs = require("fs"),
     uuid = require("uuid").v1,
-    tmpDir = require("os").tmpdir();
+    tmpDir = require("os").tmpdir(),
+    _ = require('lodash');
 
  var options;
 function writeHtmlFile(opt, type, id, cb) {
@@ -32,7 +33,8 @@ function writeHtml(opt, id, cb) {
     });
 }
 
-function convert(opt, cb) {
+function convert(options, cb) {
+    var opt = _.cloneDeep(options);
     if (typeof opt == 'string' || opt instanceof String) {
         opt = {
             html: opt


### PR DESCRIPTION
I was running into an issue when running this behind a webserver as a microservice. Basically the first request would generate the pdf as expected however subsequent requests were returning the same PDF.  After some debugging I found that the HTML files are being written correctly but options isn't getting updated.

Here is the options on the first pass:
```javascript
{ 
    allowLocalFilesAccess: true,
    printDelay: 5000,
    settings: { javascriptEnabled: true },
    html: '<html>\n    <head></head>\n    <body>\n        <h1>blah</h1>\n    </body>\n</html>\n',
    footer: '<span style="float:left">Date Generated: 08-Sep-2016 12:17:36 (GMT -0500)</span>' 
}
```

And on the second:
```javascript
{ allowLocalFilesAccess: true,
  printDelay: 5000,
  settings: { javascriptEnabled: true },
  footer: '<span style="float:left">Date Generated: 08-Sep-2016 12:20:28 (GMT -0500)</span>',
  viewportSize: {},
  paperSize: {},
  waitForJSVarName: 'PHANTOM_HTML_TO_PDF_READY',
  htmlFile: '/tmp/2337a2d0-75e8-11e6-9a97-dbf70888544fhtml.html',
  footerFile: '/tmp/2337a2d0-75e8-11e6-9a97-dbf70888544ffooter.html',
  url: 'file:///%2Ftmp%2F2337a2d0-75e8-11e6-9a97-dbf70888544fhtml.html',
  output: '/tmp/2337a2d0-75e8-11e6-9a97-dbf70888544f.pdf',
  html: '<html>\n    <head></head>\n    <body>\n        <h1>blah2</h1>\n    </body>\n</html>\n' }
```

Notice that the url is already set to the previous HTML document. And based on this code:
```javascript
opt.url = opt.url || "file:///" + encodeURIComponent(opt.htmlFile);
```
It would reuse the same url over and over again.

My change just uses lodash to do a deep clone of the the options passed in so that any modifications that are done are not passed on to subsequent request.