### PR TITLE
Update To Fit to Page setting

### DIFF
--- a/lib/scripts/conversionScriptPart.js
+++ b/lib/scripts/conversionScriptPart.js
@@ -121,14 +121,17 @@ page.open(body.url, function () {
     }
 
     if(body.fitToPage) {
-        page.evaluate(function() {
-            var scrollWidth = document.body.scrollWidth;
-            var offsetWidth = document.body.offsetWidth;
-            if(scrollWidth > offsetWidth) {
-                document.body.style.zoom =
-                    (offsetWidth / scrollWidth);
-            }
+        var widths = page.evaluate(function() {
+            return {
+                scrollWidth : document.body.scrollWidth,
+                offsetWidth : document.body.offsetWidth
+            };
         });
+
+        if(widths.scrollWidth > widths.offsetWidth) {
+            page.zoomFactor =(widths.offsetWidth / widths.scrollWidth);
+        }
+
     }
 
     setTimeout(function () {


### PR DESCRIPTION
Update fitToPage to use phantom's zoomFactor rather than setting the zoom on the body. This works better for elements like svgs and other types of images.