### PR TITLE
reset zoomFactor after page render

### DIFF
--- a/lib/scripts/conversionScriptPart.js
+++ b/lib/scripts/conversionScriptPart.js
@@ -120,6 +120,7 @@ page.open(body.url, function () {
         page.customHeaders = body.customHeaders;
     }
 
+    page.zoomFactor = 1;
     if(body.fitToPage) {
         var widths = page.evaluate(function() {
             return {


### PR DESCRIPTION
After some more testing with my previous changes, it seems I introduced a bug. When setting the zoomFactor it needs to be reset after the page render, otherwise it will effect new pages as them come in, causing elements to be cut off.