### PR TITLE
Allow for JS scripts to be injected

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ conversion({
 	},
   fitToPage: false, //whether to set zoom if contents don't fit on the page
 	customHeaders: [],
+	injectJs: [], // injects javascript files in the page
 	settings: {
 		javascriptEnabled : true,
 		resourceTimeout: 1000

--- a/lib/conversion.js
+++ b/lib/conversion.js
@@ -46,6 +46,7 @@ function convert(conversionOptions, cb) {
     opt.settings = opt.settings || {};
     opt.fitToPage = opt.fitToPage || false;
     opt.waitForJSVarName = opt.waitForJSVarName  || 'PHANTOM_HTML_TO_PDF_READY';
+    opt.injectJs = opt.injectJs || [];
 
     if (opt.waitForJS && opt.settings.javascriptEnabled === false) {
         throw new Error('can\'t use waitForJS option if settings.javascriptEnabled is not activated');

--- a/lib/scripts/conversionScriptPart.js
+++ b/lib/scripts/conversionScriptPart.js
@@ -47,6 +47,13 @@ page.onError = function (msg, trace) {
 };
 
 page.onInitialized = function() {
+    if (body.injectJs && body.injectJs.length > 0) {
+        body.injectJs.forEach(function(script) {
+            console.log('Injecting ' + script);
+            page.injectJs(script);
+        });
+    }
+
     // inject function to the page in order to the client can instruct the ending of its JS
     if (body.waitForJS) {
         page.evaluate(function(varName) {

--- a/test/injectjs.js
+++ b/test/injectjs.js
@@ -1,0 +1,1 @@
+console.log('INJECTJS TEST');

--- a/test/test.js
+++ b/test/test.js
@@ -223,6 +223,21 @@ describe("phantom html to pdf", function () {
                 done();
             });
         });
+
+        it('should allow to inject js files to the page', function(done) {
+            conversion({
+                html: 'foo',
+                injectJs: [
+                    path.join(__dirname, 'injectjs.js')
+                ]
+            }, function(err, res) {
+                if (err)
+                    return done(err);
+
+                JSON.stringify(res.logs).should.containEql('INJECTJS TEST');
+                done();
+            })
+        });
     }
 
     rmDir = function (dirPath) {


### PR DESCRIPTION
This functionality allows you to inject JS files like [the regular phantomjs implementation](http://phantomjs.org/api/webpage/method/inject-js.html) as proposed in issue #45. I've changed the parameter name to `injectJs` so it matches with the phantomjs implementation.

Usage:
```js
  conversion({
    url: "http://example.com",
    injectJs: [
      __dirname + '/polyfill.js' // <-- include the full path to the script(s) to be injected
    ]
  }, function(err, pdf) {
    ...
  });
```

Unit tests are included for both phantom-server and dedicated-process implementations. Perhaps we could create a helper file to keep the strings in the test file and the file to be injected matched up.