### PR TITLE
remove pdf temp file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Logs
 logs
 *.log
+.DS_Store
 
 # Runtime data
 pids

--- a/lib/dedicatedProcessStrategy.js
+++ b/lib/dedicatedProcessStrategy.js
@@ -1,6 +1,7 @@
 var path = require("path"),
     childProcess = require('child_process'),
-    fs = require("fs");
+    fs = require("fs"),
+    removeTempFileWhenConsumed = require('./removeTempFileWhenConsumed');
 
 
 module.exports = function(options, requestOptions, id, cb) {
@@ -58,8 +59,12 @@ module.exports = function(options, requestOptions, id, cb) {
                 m.timestamp = new Date(m.timestamp)
             })
 
+            var outputStream = fs.createReadStream(requestOptions.output);
+
+            removeTempFileWhenConsumed(requestOptions.output, outputStream);
+
             cb(null, {
-                stream: fs.createReadStream(requestOptions.output),
+                stream: outputStream,
                 numberOfPages: response.numberOfPages,
                 logs: response.logs
             });

--- a/lib/removeTempFileWhenConsumed.js
+++ b/lib/removeTempFileWhenConsumed.js
@@ -1,0 +1,34 @@
+var fs = require('fs'),
+    firstEvent = require('ee-first');
+
+module.exports = function removeTempFileWhenConsumed(filepath, fileStream) {
+  var thunk = firstEvent([
+    [fileStream, 'close', 'end', 'error']
+  ], function(err, stream, eventName, args) {
+    var shouldPropagateStreamError = false;
+
+    if (err || eventName === 'error') {
+      // if there is only one listener for the 'error' event (our handler)
+      // we should propagate the error,
+      // if there is more than one listener it means that the user is listening for the event 'error'
+      // in the stream, so it's user responsibility to handle the error correctly
+      if (fileStream.listeners('error').length === 1) {
+        shouldPropagateStreamError = true;
+      }
+    }
+
+    // clean up event listeners on stream after the callback has been executed
+    thunk.cancel();
+
+    // clean up temp file
+    deleteFile(filepath);
+
+    if (shouldPropagateStreamError) {
+      fileStream.emit('error', err);
+    }
+  });
+};
+
+function deleteFile(filepath) {
+  fs.unlink(filepath, function() { /* ignore any error when deleting the file */ });
+}

--- a/lib/serverStrategy.js
+++ b/lib/serverStrategy.js
@@ -1,6 +1,7 @@
 var Phantom = require("phantom-workers"),
     fs = require("fs"),
-    _ = require("lodash");
+    _ = require("lodash"),
+    removeTempFileWhenConsumed = require('./removeTempFileWhenConsumed');
 
 var phantoms = {};
 
@@ -61,8 +62,12 @@ module.exports = function(options, requestOptions, id, cb) {
                 m.timestamp = new Date(m.timestamp)
             })
 
+            var outputStream = fs.createReadStream(requestOptions.output);
+
+            removeTempFileWhenConsumed(requestOptions.output, outputStream);
+
             cb(null, {
-                stream: fs.createReadStream(requestOptions.output),
+                stream: outputStream,
                 numberOfPages: res.numberOfPages,
                 logs: res.logs
             });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "url": "git@github.com:pofider/phantom-html-to-pdf.git"
   },
   "dependencies": {
+    "ee-first": "1.1.1",
     "in-publish": "2.0.0",
     "lodash": "4.13.1",
     "phantom-workers": "0.4.0",

--- a/test/test.js
+++ b/test/test.js
@@ -77,6 +77,25 @@ describe("phantom html to pdf", function () {
             });
         });
 
+        it("should remove temp pdf file when consumed", function (done) {
+            conversion("foo", function (err, res) {
+                if (err)
+                    return done(err);
+
+                res.numberOfPages.should.be.eql(1);
+
+                // switching the stream to flowing mode, to consume its content
+                res.stream.on('data', function() {});
+
+                setTimeout(function() {
+                    // temp pdf file should be removed after being consumed
+                    should(fs.existsSync(res.stream.path)).be.eql(false);
+
+                    done();
+                }, 300);
+            });
+        });
+
         it("should work with multiple phantom paths", function (done) {
             conversion({ html: "foo", phantomPath: phantomjs.path}, function (err, res) {
                 if (err)


### PR DESCRIPTION
this PR implements what i say in [this issue](https://github.com/pofider/phantom-html-to-pdf/issues/44#issuecomment-272504729).

for now, i've only removed the temporal pdf file (since it is the file that causes more troubles and the most important part of this module), we can discuss if we should remove the others files (templates) here, or after rendering, or implement other technique for template sharing, personally i would vote for the remove other files after rendering.

**IMPORTANT NOTE:** the temp pdf file is only removed if the user has been consumed the file, if the file it is not consumed, the pdf file will stay on disk, let me know if you would like me to implement the remove of the file even if it is not consumed (after `conversion`'s callback execution), i have not do this because maybe there are edge cases when the pdf `stream` is used after the `conversion`'s callback execution, but we can add to docs that we always clean up the pdf file, so the user will know that it has to consume the file in `conversion`'s callback, not later because it will be removed.