### PR TITLE
Added the ability to pass zoomFactor as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ conversion({ html: "<h1>Hello World</h1>" }, function(err, pdf) {
 
 - **macOS sierra update** works only with phantomjs2, see below
 
-- **linux** may need to additionally install [fontconfig](https://www.freedesktop.org/wiki/Software/fontconfig/) package    
-*Centos*    
-`sudo yum install -y fontconfig`    
-*Debian/Ubuntu*    
+- **linux** may need to additionally install [fontconfig](https://www.freedesktop.org/wiki/Software/fontconfig/) package
+*Centos*
+`sudo yum install -y fontconfig`
+*Debian/Ubuntu*
 `sudo apt-get install -y libfontconfig`
 
 ## Global options
@@ -94,7 +94,8 @@ conversion({
 	},
 	format: {
 		quality: 100
-	}
+	},
+	zoomFactor: 1 // defaults to 1 (original size).
 }, cb);
 ```
 
@@ -107,8 +108,8 @@ var conversion = require("phantom-html-to-pdf")({
 	phantomPath: require("phantomjs-prebuilt").path
 });
 
-conversion({ 
-	html: "foo",   
+conversion({
+	html: "foo",
 }, function (err, res){});
 ```
 

--- a/lib/scripts/conversionScriptPart.js
+++ b/lib/scripts/conversionScriptPart.js
@@ -9,8 +9,8 @@ page.settings.javascriptEnabled = body.settings.javascriptEnabled !== false;
 page.settings.resourceTimeout = body.settings.resourceTimeout || 10000;
 
 
-if(body.cookies.length > 0) {
-    for(var i in body.cookies) {
+if (body.cookies.length > 0) {
+    for (var i in body.cookies) {
         page.addCookie(body.cookies[i]);
     }
 }
@@ -37,36 +37,36 @@ page.onResourceRequested = function (request, networkRequest) {
     }
 };
 
-page.onConsoleMessage = function(msg, line, source) {
+page.onConsoleMessage = function (msg, line, source) {
     console.log(msg, line, source);
 };
 
-page.onResourceError = function(resourceError) {
+page.onResourceError = function (resourceError) {
     console.warn('Unable to load resource (#' + resourceError.id + 'URL:' + resourceError.url + ')');
     console.warn('Error code: ' + resourceError.errorCode + '. Description: ' + resourceError.errorString);
 };
 
 page.onError = function (msg, trace) {
     console.warn(msg);
-    trace.forEach(function(item) {
+    trace.forEach(function (item) {
         console.warn('  ', item.file, ':', item.line);
     });
 };
 
-page.onInitialized = function() {
+page.onInitialized = function () {
     if (body.injectJs && body.injectJs.length > 0) {
-        body.injectJs.forEach(function(script) {
+        body.injectJs.forEach(function (script) {
             console.log('Injecting ' + script);
             page.injectJs(script);
         });
     }
-   
+
     // inject function to the page in order to the client can instruct the ending of its JS
     if (body.waitForJS) {
-        page.evaluate(function(varName) {
+        page.evaluate(function (varName) {
             if (typeof Object.defineProperty === 'function') {
                 Object.defineProperty(window, varName, {
-                    set: function(val) {
+                    set: function (val) {
                         if (!val)
                             return;
 
@@ -83,7 +83,7 @@ page.onInitialized = function() {
 };
 
 page.open(body.url, function () {
-    
+
     var phantomHeader = page.evaluate(function (s) {
         return document.querySelector(s) ? document.querySelector(s).innerHTML : null;
     }, '#phantomHeader');
@@ -135,17 +135,18 @@ page.open(body.url, function () {
         page.customHeaders = body.customHeaders;
     }
 
-    page.zoomFactor = 1;
-    if(body.fitToPage) {
-        var widths = page.evaluate(function() {
+    page.zoomFactor = body.zoomFactor || 1;
+
+    if (body.fitToPage) {
+        var widths = page.evaluate(function () {
             return {
-                scrollWidth : document.body.scrollWidth,
-                offsetWidth : document.body.offsetWidth
+                scrollWidth: document.body.scrollWidth,
+                offsetWidth: document.body.offsetWidth
             };
         });
 
-        if(widths.scrollWidth > widths.offsetWidth) {
-            page.zoomFactor =(widths.offsetWidth / widths.scrollWidth);
+        if (widths.scrollWidth > widths.offsetWidth) {
+            page.zoomFactor = (widths.offsetWidth / widths.scrollWidth);
         }
 
     }
@@ -156,7 +157,7 @@ page.open(body.url, function () {
 
     function resolvePage() {
         if (body.waitForJS && !pageJSisDone) {
-            setTimeout(function() {
+            setTimeout(function () {
                 console.log('PhantomJS printing done')
                 resolvePage();
             }, 100);


### PR DESCRIPTION
The project I'm working on required me to pass zoomFactor as an option, but phantom-html-to-pdf defaults it to a 1. This tiny modification is a useful addition to this package, given that different versions of phantomjs reportedly yield PDFs with inconsistent scaling.

Don't mind the whitespace changes! :)